### PR TITLE
update to use current demo standards, update sbt + Scala, add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+
+workflows:
+  test:
+    jobs:
+      - build-run-linux:
+          context: hello-world-demos
+
+  test-daily:
+    triggers:
+    - schedule:
+        cron: "0 6 * * *"
+        filters:
+          branches:
+            only: master
+    jobs:
+    - build-run-linux:
+        context: hello-world-demos
+
+# This CI build ensures that the demo both compiles and works correctly. For the runtime test,
+# we use an SDK key and flag key that are passed in via the CircleCI project configuration;
+# the flag is configured to return a true value.
+
+jobs:
+  build-run-linux:
+    docker:
+      - image: mozilla/sbt
+    steps:
+      - checkout
+      - run:
+          name: insert SDK key and flag key into demo code
+          command: |
+            sed -i.bak "s/sdkKey *= *\".*\"/sdkKey = \"${LD_HELLO_WORLD_SDK_KEY}\"/" src/main/scala/Hello.scala
+            sed -i.bak "s/featureFlagKey *= *\".*\"/featureFlagKey = \"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" src/main/scala/Hello.scala
+      - run:
+          name: build demo
+          command: sbt compile
+      - run:
+          name: run demo
+          command: |
+            sbt run | tee output.txt
+            grep "is true for this user" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
   build-run-linux:
     docker:
       - image: mozilla/sbt
+    working_directory: /root/hello  # default of ~/project is unavailable in this Docker image
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-# LaunchDarkly Sample Scala Application
+# LaunchDarkly Sample Scala Application 
 
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
+We've built a simple console application that demonstrates how LaunchDarkly's SDK . There isn't a separate Scala SDK. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Java SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/java).
 
-Note that this sample application does not use any functional programming frameworks such as [Scalaz](https://github.com/scalaz/scalaz) or [Cats](https://typelevel.org/cats/). Rather, the application exhibits how to use the LaunchDarkly Server-Side SDK for Java in a vanilla Scala application.
+Note that this sample application does not use any functional programming frameworks such as [Scalaz](https://github.com/scalaz/scalaz) or [Cats](https://typelevel.org/cats/). Rather, the application exhibits how to use the LaunchDarkly Server-Side SDK for Java in a vanilla Scala application. Note that this is the same SDK you would use in Java; there isn't a separate Scala SDK.
+ 
+## Build instructions 
 
-## Build instructions
+This project uses [SBT](https://www.scala-sbt.org/). It requires that Java is already installed on your system (version 8 or higher). It will automatically use the latest release of the LaunchDarkly SDK with major version 5.
 
-1. Install [SBT](https://www.scala-sbt.org/).
-2. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `Main.scala`
-3. Run `sbt run` to compile and run the sample application.
+1. Edit `src/main/scala/Hello.scala` and set the value of `sdkKey` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `featureFlagKey` to the flag key.
+
+```scala
+  val sdkKey = "1234567890abcdef"
+
+  val featureFlagKey = "my-flag"
+```
+
+2. To install the SDK and build the demo: `sbt compile`
+
+3. To run the demo: `sbt run`
+
+You should see the message `"Feature flag '<flag key>' is <true/false> for this user"`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaunchDarkly Sample Scala Application 
 
-We've built a simple console application that demonstrates how LaunchDarkly's SDK . There isn't a separate Scala SDK. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Java SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/java).
+We've built a simple console application that demonstrates how to use LaunchDarkly's Java SDK in a Scala application. There isn't a separate Scala SDK. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Java SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/java).
 
 Note that this sample application does not use any functional programming frameworks such as [Scalaz](https://github.com/scalaz/scalaz) or [Cats](https://typelevel.org/cats/). Rather, the application exhibits how to use the LaunchDarkly Server-Side SDK for Java in a vanilla Scala application. Note that this is the same SDK you would use in Java; there isn't a separate Scala SDK.
  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We've built a simple console application that demonstrates how to use LaunchDarkly's Java SDK in a Scala application. There isn't a separate Scala SDK. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Java SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/java).
 
-Note that this sample application does not use any functional programming frameworks such as [Scalaz](https://github.com/scalaz/scalaz) or [Cats](https://typelevel.org/cats/). Rather, the application exhibits how to use the LaunchDarkly Server-Side SDK for Java in a vanilla Scala application. Note that this is the same SDK you would use in Java; there isn't a separate Scala SDK.
+Note that this sample application does not use any functional programming frameworks such as [Scalaz](https://github.com/scalaz/scalaz) or [Cats](https://typelevel.org/cats/). Rather, the application exhibits how to use the LaunchDarkly Server-Side SDK for Java in a vanilla Scala application.
  
 ## Build instructions 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,13 @@
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.5"
 
 resolvers += Resolver.sonatypeRepo("public")
 
-// the LaunchDarkly client dependency
-libraryDependencies += "com.launchdarkly" % "launchdarkly-java-server-sdk" % "4.6.4"
+trapExit := false  // this allows the demo to use System.exit(1) to signal an error
 
-// Provides a logger implementation; this dependency is not used directly by the LD client
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
+// The LaunchDarkly SDK dependency
+libraryDependencies += "com.launchdarkly" % "launchdarkly-java-server-sdk" % "[5.0,6.0)"
+
+// Adding slf4j-simple enables the basic console logging implementation of SLF4J. Most real
+// applications will use one of the other SLF4J adapters. See: http://www.slf4j.org/
+libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.22"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.9

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,13 @@
+# SLF4J's SimpleLogger configuration file
+
+# For the purposes of this demo, we are using the simple console logging implementation that is
+# provided by org.slf4j:slf4j-simple. In a real application, there are many possible ways to
+# configure the logging behavior. See: http://www.slf4j.org/
+
+# Set defaultLogLevel to "debug" to see more detailed log output from the SDK.
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showLogName=true

--- a/src/main/scala/Hello.scala
+++ b/src/main/scala/Hello.scala
@@ -1,27 +1,47 @@
-// The JavaConversions package sprinkles in some Java/Scala interoperability magic 
-// to convert a scala.collection.immutable.List to a java.util.List
-import scala.collection.JavaConversions._ 
 
-// Import the LaunchDarkly client
-import com.launchdarkly.client.{LDClient, LDUser};
+import com.launchdarkly.sdk.LDUser
+import com.launchdarkly.sdk.server.LDClient
 
 object Main extends App {
-   val client = new LDClient("YOUR_SDK_KEY")
+  // Set sdkKey to your LaunchDarkly SDK key.
+  val sdkKey = ""
 
-   val user = new LDUser.Builder("bob@example.com")
-      .firstName("Bob")
-      .lastName("Loblaw")
-      .customString("groups", List("beta_testers"))
-      .build
+  // Set featureFlagKey to the feature flag key you want to evaluate.
+  val featureFlagKey = "my-boolean-flag"
 
-   val showFeature = client.boolVariation("YOUR_FEATURE_KEY", user, false)
+  def showMessage(s: String): Unit = {
+    println(s"*** $s")
+    println()
+  }
 
-   if (showFeature) {
-      println("Showing your feature")
-   } else {
-      println("Not showing your feature")
-   }
+  if (sdkKey == "") {
+    showMessage("Please edit Hello.scala to set sdkKey to your LaunchDarkly SDK key first")
+    System.exit(1)
+  }
 
-   client.flush
-   client.close
+  val client = new LDClient(sdkKey)
+
+  if (client.isInitialized) {
+    showMessage("SDK successfully initialized!")
+  } else {
+    showMessage("SDK failed to initialize")
+    System.exit(1)
+  }
+
+  // Set up the user properties. This user should appear on your LaunchDarkly users dashboard
+  // soon after you run the demo.
+  val user = new LDUser.Builder("example-user-key")
+    .name("Sandy")
+    .build
+
+  val flagValue = client.boolVariation(featureFlagKey, user, false)
+
+  showMessage(s"Feature flag '$featureFlagKey' is $flagValue for this user")
+
+  // Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
+  // events to LaunchDarkly before the program exits. If analytics events are not delivered,
+  // the user properties and flag usage statistics will not appear on your dashboard. In a
+  // normal long-running application, the SDK would continue running and events would be
+  // delivered automatically in the background.
+  client.close
 }


### PR DESCRIPTION
This demo was further out of date than the others, so besides standardizing the output and the readme, I also updated the versions of Scala and SBT to more recent ones (SBT is now at 1.5.0, but that's still pretty new so I used the latest 1.4.x) and more importantly updated the LaunchDarkly Java SDK to the current major version.